### PR TITLE
Fix bug in code for rethrowing exceptions in worker threads.

### DIFF
--- a/src/main/java/edu/ucsd/msjava/ui/MSGFPlus.java
+++ b/src/main/java/edu/ucsd/msjava/ui/MSGFPlus.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -306,6 +307,7 @@ public class MSGFPlus {
             }
 
             try {
+                final ArrayList<Future<?>> futures = new ArrayList<Future<?>>();
                 for (int i = 0; i < numTasks; i++) {
                     ScoredSpectraMap specScanner = new ScoredSpectraMap(
                             specAcc,
@@ -328,20 +330,23 @@ public class MSGFPlus {
                             resultList,
                             i + 1
                     );
-                    executor.execute(msgfdbExecutor);
+                    futures.add(executor.submit(msgfdbExecutor));
                 }
 
                 executor.shutdown();
 
                 int outputLimitCounter = 0;
-                while (executor.getActiveCount() > 0) {
-                    if (executor.HasThrownData()) {
-                        // One task threw an exception, so all of the results will be incomplete. Exit.
-                        Throwable data = executor.getThrownData();
-                        if (data instanceof OutOfMemoryError) {
-                            throw (OutOfMemoryError) data;
-                        } else {
-                            throw data;
+                while (!futures.isEmpty()) {
+                    for(final java.util.Iterator<Future<?>> it = futures.iterator(); it.hasNext();){
+                        final Future<?> f = it.next();
+                        if (f.isDone()){
+                            try {
+                                f.get();
+                            } catch (java.util.concurrent.ExecutionException e) {
+                                // One task threw an exception, so all of the results will be incomplete. Exit.
+                                throw e.getCause();
+                            }
+                            it.remove();
                         }
                     }
 


### PR DESCRIPTION
Current code will often miss an exception thrown by the last thread. This occurs frequently if there is only one thread (using “-thread 1”) in the thread pool.

The while loop [here](https://github.com/sangtaekim/msgfplus/blob/09b739a8fe9f77d095e8108be907f180d495cddc/src/main/java/edu/ucsd/msjava/ui/MSGFPlus.java#L337) checks the condition “executor.getActiveCount() > 0” at the beginning of each iteration. The last active thread could have ended during the previous “Thread.sleep(1000);” and thrown an exception. But that exception will not be rethrown because “executor.getActiveCount() == 0” and we break out of the while loop.